### PR TITLE
moved bindata.go to internal package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 		rm -rf build/
 
 assets:
-	go-bindata -nomemcopy -pkg govatar data/...
+	go-bindata -nomemcopy -pkg bindata -o internal/bindata/bindata.go data/...
 
 $(PLATFORMS):
 	GOOS=$(os) GOARCH=$(arch) go build -ldflags "-X main.version=${VERSION}" -o 'build/govatar$(ext)' github.com/o1egl/govatar/govatar

--- a/govatar.go
+++ b/govatar.go
@@ -3,7 +3,6 @@ package govatar
 import (
 	"bytes"
 	"errors"
-	"github.com/skarademir/naturalsort"
 	"image"
 	"image/draw"
 	"image/gif"
@@ -15,6 +14,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/o1egl/govatar/internal/bindata"
+	"github.com/skarademir/naturalsort"
 )
 
 type person struct {
@@ -136,7 +138,7 @@ func drawImg(dst draw.Image, asset string, err error) error {
 	if err != nil {
 		return err
 	}
-	src, _, err := image.Decode(bytes.NewReader(MustAsset(asset)))
+	src, _, err := image.Decode(bytes.NewReader(bindata.MustAsset(asset)))
 	if err != nil {
 		return err
 	}
@@ -154,7 +156,7 @@ func getPerson(gender string) person {
 }
 
 func readAssetsFrom(dir string) []string {
-	assets, _ := AssetDir(dir)
+	assets, _ := bindata.AssetDir(dir)
 	for i, asset := range assets {
 		assets[i] = filepath.Join(dir, asset)
 	}


### PR DESCRIPTION
The go-bindata generated methods are public in the govatar lib package and pollute the godoc.  This pull request puts the go-bindata data output in internal/bindata so the generated methods are not exposed.

If you intended to expose those functions please ignore.  Cool project!