### PR TITLE
Update govatar.go

### DIFF
--- a/govatar.go
+++ b/govatar.go
@@ -176,6 +176,7 @@ func mustAssetsList(dir string) []string {
 	assets := make([]string, len(dirEntries))
 	for i, dirEntry := range dirEntries {
 		assets[i] = filepath.Join(dir, dirEntry.Name())
+		assets[i] = filepath.ToSlash(assets[i])
 	}
 	sort.Sort(naturalSort(assets))
 	return assets


### PR DESCRIPTION
An error was found
------------------
win10 
go 1.16
govatar 0.4.0

`panic: open data\background\backgroundX.png: file does not exist`

![image](https://user-images.githubusercontent.com/24670171/110659388-80a5f180-81fd-11eb-9d02-eabd0990ebb6.png)